### PR TITLE
Initial implementation of job summary

### DIFF
--- a/src/main/kotlin/com/springernature/newversion/Main.kt
+++ b/src/main/kotlin/com/springernature/newversion/Main.kt
@@ -20,5 +20,7 @@ fun main() {
         is SuccessfulChecks -> Unit
     }
 
+    SummaryWriter(System.getenv("GITHUB_STEP_SUMMARY")).write(results)
+
     exitProcess(results.exitStatus())
 }

--- a/src/main/kotlin/com/springernature/newversion/SummaryWriter.kt
+++ b/src/main/kotlin/com/springernature/newversion/SummaryWriter.kt
@@ -1,0 +1,46 @@
+package com.springernature.newversion
+
+import java.io.File
+
+class SummaryWriter(val file: File) {
+
+    constructor(filename: String?) : this(
+        if (filename == null || filename.isBlank()) {
+            System.err.println("no filename for report provided, will not create a report")
+            File("/dev/null")
+        } else {
+            File(filename)
+        })
+
+    fun write(results: ChecksResult) {
+        writeHeader(file)
+        when (results) {
+            is FailedChecks -> {
+                writeFailures(results.errors)
+                writeSuccessfulUpdates(results.updates)
+            }
+            is SuccessfulChecks -> writeSuccessfulUpdates(results.updates)
+        }
+        writeFooter(file)
+    }
+
+    private fun writeHeader(file: File) {
+        file.writeText("# CF buildpack update action results\n")
+    }
+
+    private fun writeSuccessfulUpdates(updates: List<BuildpackUpdate>) {
+        file.appendText("\n## success\n\n")
+        updates.forEach { file.appendText("* currentBuildpack ${it.currentBuildpack} ${if (it.hasUpdate()) "has an update to " + it.latestUpdate else "has no update"}\n") }
+    }
+
+    private fun writeFailures(errors: Map<BuildpackUpdate, Exception>) {
+        file.appendText("\n## failures\n" +
+                "\n")
+        errors.forEach { file.appendText("* ${it.key.currentBuildpack} could not be updated: ${it.value}\n") }
+    }
+
+    private fun writeFooter(file: File) {
+        file.appendText("\nThanks for watching!\n")
+    }
+
+}

--- a/src/test/kotlin/com/springernature/newversion/SummaryWriterTest.kt
+++ b/src/test/kotlin/com/springernature/newversion/SummaryWriterTest.kt
@@ -1,0 +1,65 @@
+package com.springernature.newversion
+
+import org.amshove.kluent.fail
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class SummaryWriterTest {
+
+    @Test
+    fun `successful checks report`() {
+        val tempFile = getTempReportFile()
+
+        SummaryWriter(tempFile).write(successfulChecksResults)
+
+        tempFile.readText() shouldBeEqualTo "# CF buildpack update action results\n" + "\n" + "## success\n" + "\n" + "* currentBuildpack VersionedBuildpack(name=test/buildpack1, url=https://a.host/path, version=1.3, tag=GitTag(value=v1.3)) has no update\n" + "\n" + "Thanks for watching!\n"
+    }
+
+    @Test
+    fun `failed checks report`() {
+        val updates: List<BuildpackUpdate> = listOf(buildpackUpdate)
+        val errors = mapOf(Pair(buildpackUpdate, RuntimeException("Successful failure!")))
+        val results = FailedChecks(updates, errors)
+
+        val tempFile = getTempReportFile()
+
+        SummaryWriter(tempFile).write(results)
+
+        tempFile.readText() shouldBeEqualTo "# CF buildpack update action results\n" + "\n" + "## failures\n" + "\n" + "* VersionedBuildpack(name=test/buildpack1, url=https://a.host/path, version=1.3, tag=GitTag(value=v1.3)) could not be updated: java.lang.RuntimeException: Successful failure!\n" + "\n" + "## success\n" + "\n" + "* currentBuildpack VersionedBuildpack(name=test/buildpack1, url=https://a.host/path, version=1.3, tag=GitTag(value=v1.3)) has no update\n" + "\n" + "Thanks for watching!\n"
+    }
+
+    @Test
+    fun `handle blank filename`() {
+        try {
+            SummaryWriter("").write(successfulChecksResults)
+        } catch (e: Exception) {
+            fail("Unexpected exception: $e")
+        }
+    }
+
+    @Test
+    fun `handle null filename`() {
+        try {
+            SummaryWriter(null).write(successfulChecksResults)
+        } catch (e: Exception) {
+            fail("Unexpected exception: $e")
+        }
+    }
+
+    companion object {
+        val buildpackUpdate = BuildpackUpdate(listOf(File("a/path")),
+            VersionedBuildpack("test/buildpack1", "https://a.host/path", SemanticVersion("1.3"), GitTag("v1.3")),
+            BuildpackVersion(SemanticVersion("1.2.4"), GitTag("v1.2.4")))
+
+        val successfulChecksResults = SuccessfulChecks(listOf(buildpackUpdate))
+
+        private fun getTempReportFile(): File {
+            val tempFile = kotlin.io.path.createTempFile(suffix = ".md").toFile()
+            tempFile.deleteOnExit()
+            return tempFile
+        }
+
+    }
+
+}


### PR DESCRIPTION
Inspired by …
* [Supercharging GitHub Actions with Job Summaries | The GitHub Blog](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/)
* [Workflow commands for GitHub Actions - GitHub Docs](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path)

… initial implementation, just to see that it's working. The report itself is still very basic.

As always: please feel free to criticise everything: style, shape, colour, etc  :smile: 
Thanks!