### PR TITLE
Bumps jackson  from 2.14.1 to 2.14.2.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,8 +15,8 @@ repositories {
 dependencies {
     implementation("org.slf4j:slf4j-api:2.0.6")
     implementation("com.lordcodes.turtle:turtle:0.8.0")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.1")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.1")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.2")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.2")
     implementation("net.swiftzer.semver:semver:1.2.0")
 
     runtimeOnly("ch.qos.logback:logback-classic:1.4.5")


### PR DESCRIPTION
* Bumps jackson-module-kotlin from 2.14.1 to 2.14.2., see PR #52
* Bumps jackson-dataformat-yaml from 2.14.1 to 2.14.2., see PR #53
