### PR TITLE
Check paketo buildpacks

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,64 @@
 # History
 
+## [1.1.0](https://github.com/springernature/cf-buildpack-update-action/compare/v1.0.10...v1.1.0)
+
+* Add support for updating Paketo buildpacks in Halfpipe pipelines (`.halfpipe.io` files)
+* Add support for updating Paketo buildpacks in GitHub Actions workflows
+* Document CNB buildpack scanning in README
+* Replace semver library to allow non-strict version parsing
+* Dependency updates
+
+## [1.0.10](https://github.com/springernature/cf-buildpack-update-action/compare/v1.0.9...v1.0.10)
+
+* Use current version of `actions/checkout` in example
+* Fix duplicate execution of checks
+* Run tests on all PRs against main
+* Dependency updates
+
+## [1.0.9](https://github.com/springernature/cf-buildpack-update-action/compare/v1.0.8...v1.0.9)
+
+* Add explicit dependency on `junit-platform-launcher` to prepare for Gradle 9.0
+* Dependency updates
+
+## [1.0.8](https://github.com/springernature/cf-buildpack-update-action/compare/v1.0.7...v1.0.8)
+
+* Add documentation for GitHub job summary
+* Add CodeQL security scanning
+* Add Gradle dependency submission
+* Add Gradle wrapper validation and auto-update actions
+
+## [1.0.7](https://github.com/springernature/cf-buildpack-update-action/compare/v1.0.6...v1.0.7)
+
+* Upgrade to JDK 17
+* Log process stdout and stderr as they happen rather than waiting for completion
+* Dependency updates
+
+## [1.0.6](https://github.com/springernature/cf-buildpack-update-action/compare/v1.0.5...v1.0.6)
+
+* Add GitHub job summary, disabled by default and enabled by setting `GITHUB_STEP_SUMMARY_ENABLED=true`
+
+## [1.0.5](https://github.com/springernature/cf-buildpack-update-action/compare/v1.0.4...v1.0.5)
+
+* Exit with non-zero exit code on failure to publish
+* Print errors to standard error output stream
+
+## [1.0.4](https://github.com/springernature/cf-buildpack-update-action/compare/v1.0.3...v1.0.4)
+
+* Add GitHub action branding
+* Add Dependabot configuration
+* Add documentation for keeping the action up-to-date with Dependabot
+
+## [1.0.3](https://github.com/springernature/cf-buildpack-update-action/compare/v1.0.2...v1.0.3)
+
+* Rename to `cf-buildpack-update-action`
+* Add support for parsing built-in CF buildpacks
+* Extend manifest file detection to include YAML files with `cf` in the name
+
+## [1.0.2](https://github.com/springernature/cf-buildpack-update-action/compare/v1.0.1...v1.0.2)
+
+* Make version parsing stricter to avoid attempting updates for buildpacks pinned to a branch or non-semver tag
+* Open sourced under GPL 3
+
 ## 1.0.1
 
-* Initial release.
+* Initial release

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Create a file in your repo called `.github/workflows/buildpack-update.yml` and i
           - name: Check out the repo
             uses: actions/checkout@v4
           - name: run cf-buildpack-update-action
-            uses: springernature/cf-buildpack-update-action@v1.0.10
+            uses: springernature/cf-buildpack-update-action@v1.1.0
             env:
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               AUTHOR_EMAIL: your-team-email-address@springernature.com

--- a/README.md
+++ b/README.md
@@ -1,16 +1,55 @@
 # Buildpack update action
 
-Create pull requests to update Cloud Foundry buildpacks in manifest files.
+Create pull requests to update buildpacks in Cloud Foundry manifest files, Halfpipe pipelines, and GitHub Actions workflows.
 
 ## Why?
 
-Aiming for reproducible deployments it's a necessary step to pin a buildpack in a project to a specific version in the
-Cloud Foundry manifest, so it will always use the one you specify.
+Aiming for reproducible deployments it's a necessary step to pin a buildpack in a project to a specific version, so it
+will always use the one you specify.
 
 The disadvantage of pinning is that any improvement in a newer version is not automatically taken over to the project.
 
 With this GitHub action a pull request will be created if there is a newer version of a buildpack available. That way
 the project can stay up-to-date but with a conscious and deliberate change, traceable in version control.
+
+## What is scanned?
+
+The action scans the repository for buildpack references in three places:
+
+### Cloud Foundry manifests (`manifest.yml`)
+
+Pinned [classic CF buildpacks](https://docs.cloudfoundry.org/buildpacks/) referenced by GitHub URL and version tag:
+
+```yaml
+applications:
+  - name: my-app
+    buildpacks:
+      - https://github.com/cloudfoundry/java-buildpack#v4.50.0
+```
+
+### Halfpipe pipelines (`.halfpipe.io`, `.halfpipe.io.yml`, `.halfpipe.io.yaml`)
+
+Pinned [Paketo buildpacks](https://paketo.io) in `buildpack` tasks:
+
+```yaml
+tasks:
+  - type: buildpack
+    image: eu.gcr.io/halfpipe-io/my-team/my-app
+    buildpacks:
+      - paketo-buildpacks/java:21.4.0
+```
+
+### GitHub Actions workflows (`.github/workflows/*.yml`)
+
+Pinned Paketo buildpacks passed to steps via the `buildpacks` input (e.g. when using
+[ee-action-buildpack](https://github.com/springernature/ee-action-buildpack)):
+
+```yaml
+- name: Pack n Push
+  uses: springernature/ee-action-buildpack@v1
+  with:
+    buildpacks: paketobuildpacks/java:21.4.0
+```
 
 ## Example usage
 

--- a/src/main/kotlin/com/springernature/newversion/BuildpackVersionChecker.kt
+++ b/src/main/kotlin/com/springernature/newversion/BuildpackVersionChecker.kt
@@ -27,13 +27,21 @@ class BuildpackVersionChecker(
     fun performChecks(): ChecksResult {
         LOG.info("Performing checks")
         val errors = LinkedHashMap<BuildpackUpdate, Exception>()
-        val updates = ManifestParser.load(manifestPath)
+
+        val cfBuildpacks = ManifestParser.load(manifestPath)
             .flatMap { ManifestBuildpack.from(it) }
+            .map { ManifestEntry(it.manifest, it.buildpack) }
+
+        val paketoBuildpacks = (HalfpipeManifestParser.load(manifestPath) + GitHubActionsManifestParser.load(manifestPath))
+            .flatMap { PaketoManifestBuildpack.from(it) }
+            .map { ManifestEntry(it.manifest, it.buildpack) }
+
+        val updates = (cfBuildpacks + paketoBuildpacks)
             .filter { it.buildpack.version != Unparseable }
             .groupBy { it.buildpack }
-            .map { (buildpack, manifestBuildpacks) ->
+            .map { (buildpack, entries) ->
                 BuildpackUpdate(
-                    manifestBuildpacks.map { it.manifest },
+                    entries.map { it.manifest },
                     buildpack,
                     buildpackUpdateChecker.findLatestVersion(buildpack)
                 )
@@ -57,6 +65,8 @@ class BuildpackVersionChecker(
         private val LOG: Logger = LoggerFactory.getLogger(BuildpackVersionChecker::class.java)
     }
 
+    private data class ManifestEntry(val manifest: File, val buildpack: VersionedBuildpack)
+
     private data class ManifestBuildpack(val manifest: File, val buildpack: VersionedBuildpack) {
 
         companion object {
@@ -70,6 +80,22 @@ class BuildpackVersionChecker(
                 is Manifest -> manifest.applications.flatMap { app -> app.buildpacks() }.map {
                     ManifestBuildpack(manifest.path, it)
                 }
+            }
+        }
+
+    }
+
+    private data class PaketoManifestBuildpack(val manifest: File, val buildpack: VersionedBuildpack) {
+
+        companion object {
+            private val LOG: Logger = LoggerFactory.getLogger(PaketoManifestBuildpack::class.java)
+
+            fun from(result: PaketoManifestLoadResult): List<PaketoManifestBuildpack> = when (result) {
+                is FailedPaketoManifest -> {
+                    LOG.warn("Failed to parse Paketo manifest {}: {}", result.path, result.error.message)
+                    emptyList()
+                }
+                is PaketoManifest -> result.buildpacks.map { PaketoManifestBuildpack(result.path, it) }
             }
         }
 

--- a/src/main/kotlin/com/springernature/newversion/BuildpackVersionChecker.kt
+++ b/src/main/kotlin/com/springernature/newversion/BuildpackVersionChecker.kt
@@ -92,7 +92,7 @@ class BuildpackVersionChecker(
 
             fun from(result: PaketoManifestLoadResult): List<PaketoManifestBuildpack> = when (result) {
                 is FailedPaketoManifest -> {
-                    LOG.warn("Failed to parse Paketo manifest {}: {}", result.path, result.error.message)
+                    LOG.warn("Failed to parse Paketo manifest {}: {}", result.path, result.error.message, result.error)
                     emptyList()
                 }
                 is PaketoManifest -> result.buildpacks.map { PaketoManifestBuildpack(result.path, it) }

--- a/src/main/kotlin/com/springernature/newversion/GitHubActionsManifestParser.kt
+++ b/src/main/kotlin/com/springernature/newversion/GitHubActionsManifestParser.kt
@@ -29,7 +29,7 @@ object GitHubActionsManifestParser {
                     .map { VersionedBuildpack.createPaketo(it) }
                 PaketoManifest(buildpacks, file)
             } catch (e: Exception) {
-                LOG.warn("Failed to parse workflow file {}: {}", file, e.message)
+                LOG.warn("Failed to parse workflow file {}", file, e)
                 FailedPaketoManifest(file, e)
             }
         }

--- a/src/main/kotlin/com/springernature/newversion/GitHubActionsManifestParser.kt
+++ b/src/main/kotlin/com/springernature/newversion/GitHubActionsManifestParser.kt
@@ -1,0 +1,67 @@
+package com.springernature.newversion
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.io.File
+
+object GitHubActionsManifestParser {
+
+    private val LOG: Logger = LoggerFactory.getLogger(GitHubActionsManifestParser::class.java)
+
+    fun load(dir: File): Sequence<PaketoManifestLoadResult> = dir.walk()
+        .filter { it.isFile }
+        .filterNot { it.path.contains("/.git/") }
+        .filter { isWorkflowFile(it) }
+        .onEach { LOG.debug("Found GitHub Actions workflow {}", it) }
+        .map { file ->
+            try {
+                val parsed = readWorkflowFile(file)
+                val buildpacks = parsed.jobs.values
+                    .flatMap { it.steps }
+                    .mapNotNull { it.with?.buildpacks }
+                    .filter { it.contains(":") }
+                    .map { VersionedBuildpack.createPaketo(it) }
+                PaketoManifest(buildpacks, file)
+            } catch (e: Exception) {
+                LOG.warn("Failed to parse workflow file {}: {}", file, e.message)
+                FailedPaketoManifest(file, e)
+            }
+        }
+
+    private fun isWorkflowFile(file: File): Boolean {
+        val path = file.path
+        val ext = file.extension.lowercase()
+        return (ext == "yml" || ext == "yaml") && path.contains("/.github/workflows/")
+    }
+
+    private fun readWorkflowFile(f: File): WorkflowFile = ObjectMapper(YAMLFactory())
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .registerKotlinModule()
+        .readValue(f)
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private data class WorkflowFile(
+        val jobs: Map<String, WorkflowJob> = emptyMap()
+    )
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private data class WorkflowJob(
+        val steps: List<WorkflowStep> = emptyList()
+    )
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private data class WorkflowStep(
+        val with: WithBlock? = null
+    )
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private data class WithBlock(
+        val buildpacks: String? = null
+    )
+}

--- a/src/main/kotlin/com/springernature/newversion/GitHubActionsManifestParser.kt
+++ b/src/main/kotlin/com/springernature/newversion/GitHubActionsManifestParser.kt
@@ -16,7 +16,7 @@ object GitHubActionsManifestParser {
 
     fun load(dir: File): Sequence<PaketoManifestLoadResult> = dir.walk()
         .filter { it.isFile }
-        .filterNot { it.path.contains("/.git/") }
+        .filterNot { it.invariantSeparatorsPath.contains("/.git/") }
         .filter { isWorkflowFile(it) }
         .onEach { LOG.debug("Found GitHub Actions workflow {}", it) }
         .map { file ->
@@ -35,7 +35,7 @@ object GitHubActionsManifestParser {
         }
 
     private fun isWorkflowFile(file: File): Boolean {
-        val path = file.path
+        val path = file.invariantSeparatorsPath
         val ext = file.extension.lowercase()
         return (ext == "yml" || ext == "yaml") && path.contains("/.github/workflows/")
     }

--- a/src/main/kotlin/com/springernature/newversion/HalfpipeManifestParser.kt
+++ b/src/main/kotlin/com/springernature/newversion/HalfpipeManifestParser.kt
@@ -22,7 +22,7 @@ object HalfpipeManifestParser {
 
     fun load(dir: File): Sequence<PaketoManifestLoadResult> = dir.walk()
         .filter { it.isFile }
-        .filterNot { it.path.contains("/.git/") }
+        .filterNot { it.invariantSeparatorsPath.contains("/.git/") }
         .filter { it.name in HALFPIPE_FILENAMES }
         .onEach { LOG.debug("Found halfpipe manifest {}", it) }
         .map { file ->

--- a/src/main/kotlin/com/springernature/newversion/HalfpipeManifestParser.kt
+++ b/src/main/kotlin/com/springernature/newversion/HalfpipeManifestParser.kt
@@ -1,0 +1,56 @@
+package com.springernature.newversion
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.io.File
+
+sealed class PaketoManifestLoadResult
+data class PaketoManifest(val buildpacks: List<VersionedBuildpack>, val path: File) : PaketoManifestLoadResult()
+data class FailedPaketoManifest(val path: File, val error: Exception) : PaketoManifestLoadResult()
+
+object HalfpipeManifestParser {
+
+    private val LOG: Logger = LoggerFactory.getLogger(HalfpipeManifestParser::class.java)
+
+    private val HALFPIPE_FILENAMES = setOf(".halfpipe.io", ".halfpipe.io.yaml", ".halfpipe.io.yml")
+
+    fun load(dir: File): Sequence<PaketoManifestLoadResult> = dir.walk()
+        .filter { it.isFile }
+        .filterNot { it.path.contains("/.git/") }
+        .filter { it.name in HALFPIPE_FILENAMES }
+        .onEach { LOG.debug("Found halfpipe manifest {}", it) }
+        .map { file ->
+            try {
+                val parsed = readHalfpipeFile(file)
+                val buildpacks = parsed.tasks
+                    .filter { it.type == "buildpack" }
+                    .flatMap { it.buildpacks }
+                    .filter { it.contains(":") }
+                    .map { VersionedBuildpack.createPaketo(it) }
+                PaketoManifest(buildpacks, file)
+            } catch (e: Exception) {
+                LOG.warn("Failed to parse halfpipe manifest {}: {}", file, e.message)
+                FailedPaketoManifest(file, e)
+            }
+        }
+
+    private fun readHalfpipeFile(f: File): HalfpipeFile = ObjectMapper(YAMLFactory())
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .registerKotlinModule()
+        .readValue(f)
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private data class HalfpipeFile(val tasks: List<HalfpipeTask> = emptyList())
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private data class HalfpipeTask(
+        val type: String = "",
+        val buildpacks: List<String> = emptyList()
+    )
+}

--- a/src/main/kotlin/com/springernature/newversion/HalfpipeManifestParser.kt
+++ b/src/main/kotlin/com/springernature/newversion/HalfpipeManifestParser.kt
@@ -35,7 +35,7 @@ object HalfpipeManifestParser {
                     .map { VersionedBuildpack.createPaketo(it) }
                 PaketoManifest(buildpacks, file)
             } catch (e: Exception) {
-                LOG.warn("Failed to parse halfpipe manifest {}: {}", file, e.message)
+                LOG.warn("Failed to parse halfpipe manifest {}", file, e)
                 FailedPaketoManifest(file, e)
             }
         }

--- a/src/main/kotlin/com/springernature/newversion/Manifest.kt
+++ b/src/main/kotlin/com/springernature/newversion/Manifest.kt
@@ -10,7 +10,13 @@ data class CFApplication(
     fun buildpacks() = buildpack?.let { buildpacks.plus(buildpack) } ?: buildpacks
 }
 
-data class VersionedBuildpack(val name: String, val url: String, val version: Version, val tag: GitTag?) {
+data class VersionedBuildpack(
+    val name: String,
+    val url: String,
+    val version: Version,
+    val tag: GitTag?,
+    val fileToken: String? = null
+) {
 
     companion object {
 
@@ -20,6 +26,17 @@ data class VersionedBuildpack(val name: String, val url: String, val version: Ve
         @JsonCreator
         fun create(value: String) =
             VersionedBuildpack(value.name(), value.buildpackUrl(), value.buildpackVersion(), value.buildpackTag())
+
+        fun createPaketo(value: String): VersionedBuildpack {
+            val withoutVersion = value.substringBefore(":")
+            val org = withoutVersion.substringBefore("/")
+            val repo = withoutVersion.substringAfter("/")
+            val githubOrg = org.replace("paketobuildpacks", "paketo-buildpacks")
+            val name = "$githubOrg/$repo"
+            val url = "https://github.com/$name"
+            val version = if (value.contains(":")) SemanticVersion(value.substringAfter(":")) else Unparseable
+            return VersionedBuildpack(name, url, version, tag = null, fileToken = withoutVersion)
+        }
 
         private fun String.buildpackUrl(): String =
             "(.*github.com/.*?)(?:\\.git)?(?:#v?$SEMVER_REGEX)?$".toRegex().find(this)?.groups?.get(1)?.value

--- a/src/main/kotlin/com/springernature/newversion/Publisher.kt
+++ b/src/main/kotlin/com/springernature/newversion/Publisher.kt
@@ -24,15 +24,17 @@ class GitHubPullRequestPublisher(private val shell: Shell, settings: Settings) :
     private fun BuildpackUpdate.commitMessage() =
         "Update ${currentBuildpack.name} to ${latestUpdate.version}"
 
-    private fun BuildpackUpdate.pullRequestMessage() =
-        """
+    private fun BuildpackUpdate.pullRequestMessage(): String {
+        val currentTagValue = currentBuildpack.tag?.value ?: "v${currentBuildpack.version}"
+        return """
         Update ${currentBuildpack.name} to ${latestUpdate.version}
         
         Update ${currentBuildpack.name} from ${currentBuildpack.version} to ${latestUpdate.version}.
         
         * [Release Notes](https://github.com/${currentBuildpack.name}/releases/tag/${latestUpdate.tag.value})
-        * [Diff](https://github.com/${currentBuildpack.name}/compare/${currentBuildpack.tag?.value}...${latestUpdate.tag.value})
+        * [Diff](https://github.com/${currentBuildpack.name}/compare/$currentTagValue...${latestUpdate.tag.value})
     """.trimIndent()
+    }
 
     private fun updateManifest(update: BuildpackUpdate) {
         update.manifests.forEach { manifest ->
@@ -41,7 +43,13 @@ class GitHubPullRequestPublisher(private val shell: Shell, settings: Settings) :
                 update.currentBuildpack.name, update.currentBuildpack.tag?.value, update.latestUpdate.tag.value
             )
             val manifestContent = manifest.readText(Charsets.UTF_8)
-            val newManifest =
+            val newManifest = if (update.currentBuildpack.fileToken != null) {
+                val token = update.currentBuildpack.fileToken
+                manifestContent.replace(
+                    "$token:${update.currentBuildpack.version}",
+                    "$token:${update.latestUpdate.version}"
+                )
+            } else {
                 manifestContent.replace(
                     "${update.currentBuildpack.name}#${update.currentBuildpack.tag?.value}",
                     "${update.currentBuildpack.name}#${update.latestUpdate.tag.value}"
@@ -49,6 +57,7 @@ class GitHubPullRequestPublisher(private val shell: Shell, settings: Settings) :
                     "${update.currentBuildpack.name}.git#${update.currentBuildpack.tag?.value}",
                     "${update.currentBuildpack.name}.git#${update.latestUpdate.tag.value}"
                 )
+            }
             manifest.writeText(newManifest, Charsets.UTF_8)
         }
     }

--- a/src/test/kotlin/com/springernature/newversion/BuildpackVersionCheckerTest.kt
+++ b/src/test/kotlin/com/springernature/newversion/BuildpackVersionCheckerTest.kt
@@ -161,6 +161,31 @@ class BuildpackVersionCheckerTest {
     }
 
     @Test
+    fun `paketo buildpacks in halfpipe manifests are checked and updated`() {
+        val fixtureDir = File("src/test/resources/paketo-wiring-test")
+        fixtureDir.exists() shouldBe true
+
+        val settings = Settings(mapOf(GIT_HUB_API_URL.key to baseUrl))
+        val capturingPublisher = CapturingPublisher()
+        val buildpackVersionChecker = BuildpackVersionChecker(
+            fixtureDir,
+            GitHubBuildpackUpdateChecker(HttpClient.newBuilder().build(), settings),
+            capturingPublisher
+        )
+
+        val results = buildpackVersionChecker.performChecks()
+        results shouldBeInstanceOf SuccessfulChecks::class
+
+        capturingPublisher.updates().size shouldBe 1
+        val update = capturingPublisher.updates().first()
+
+        update.currentBuildpack.name shouldBeEqualTo "paketo-buildpacks/java"
+        update.currentBuildpack.version shouldBeEqualTo SemanticVersion("21.4.0")
+        update.latestUpdate.version shouldBeEqualTo SemanticVersion("21.5.0")
+        update.latestUpdate.tag shouldBeEqualTo GitTag("v21.5.0")
+    }
+
+    @Test
     fun `a failed publish should lead to failed check`() {
         val manifest = File("src/test/resources/manifest.yml")
         manifest.exists() shouldBe true
@@ -218,6 +243,12 @@ class BuildpackVersionCheckerTest {
                 )
             }.also { server ->
                 context(server, "/repos/cloudfoundry/java-buildpack/releases/latest", "/github-latest-java.json")
+            }.also { server ->
+                context(
+                    server,
+                    "/repos/paketo-buildpacks/java/releases/latest",
+                    "/github-latest-paketo-java.json"
+                )
             }
 
         private fun context(server: HttpServer, path: String, responseFile: String) {

--- a/src/test/kotlin/com/springernature/newversion/GitHubActionsManifestParserTest.kt
+++ b/src/test/kotlin/com/springernature/newversion/GitHubActionsManifestParserTest.kt
@@ -13,7 +13,7 @@ class GitHubActionsManifestParserTest {
         val results = GitHubActionsManifestParser.load(resourcePath("github-actions-test")).toList()
 
         val manifests = results.filterIsInstance<PaketoManifest>()
-        val topLevel = manifests.first { it.path.canonicalPath.contains("/github-actions-test/.github/workflows/") }
+        val topLevel = manifests.first { it.path.invariantSeparatorsPath.contains("/github-actions-test/.github/workflows/") }
         topLevel.buildpacks shouldContain VersionedBuildpack.createPaketo("paketobuildpacks/java:21.4.0")
     }
 
@@ -22,7 +22,7 @@ class GitHubActionsManifestParserTest {
         val results = GitHubActionsManifestParser.load(resourcePath("github-actions-test")).toList()
 
         val manifests = results.filterIsInstance<PaketoManifest>()
-        val nested = manifests.first { it.path.canonicalPath.contains("/subapp/.github/workflows/") }
+        val nested = manifests.first { it.path.invariantSeparatorsPath.contains("/subapp/.github/workflows/") }
         nested.buildpacks shouldContain VersionedBuildpack.createPaketo("paketobuildpacks/nodejs:1.3.0")
     }
 
@@ -46,7 +46,7 @@ class GitHubActionsManifestParserTest {
         val results = GitHubActionsManifestParser.load(resourcePath("github-actions-test")).toList()
 
         val manifests = results.filterIsInstance<PaketoManifest>()
-        val nested = manifests.first { it.path.canonicalPath.contains("/subapp/.github/workflows/") }
+        val nested = manifests.first { it.path.invariantSeparatorsPath.contains("/subapp/.github/workflows/") }
         // Only one buildpack in that file; the setup-node step has no buildpacks
         nested.buildpacks.size shouldBe 1
     }

--- a/src/test/kotlin/com/springernature/newversion/GitHubActionsManifestParserTest.kt
+++ b/src/test/kotlin/com/springernature/newversion/GitHubActionsManifestParserTest.kt
@@ -1,0 +1,55 @@
+package com.springernature.newversion
+
+import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldContain
+import org.amshove.kluent.shouldContainAll
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class GitHubActionsManifestParserTest {
+
+    @Test
+    fun `loads buildpack from top-level workflow file`() {
+        val results = GitHubActionsManifestParser.load(resourcePath("github-actions-test")).toList()
+
+        val manifests = results.filterIsInstance<PaketoManifest>()
+        val topLevel = manifests.first { it.path.canonicalPath.contains("/github-actions-test/.github/workflows/") }
+        topLevel.buildpacks shouldContain VersionedBuildpack.createPaketo("paketobuildpacks/java:21.4.0")
+    }
+
+    @Test
+    fun `loads buildpack from nested workflow file`() {
+        val results = GitHubActionsManifestParser.load(resourcePath("github-actions-test")).toList()
+
+        val manifests = results.filterIsInstance<PaketoManifest>()
+        val nested = manifests.first { it.path.canonicalPath.contains("/subapp/.github/workflows/") }
+        nested.buildpacks shouldContain VersionedBuildpack.createPaketo("paketobuildpacks/nodejs:1.3.0")
+    }
+
+    @Test
+    fun `finds exactly two workflow files in fixture`() {
+        val results = GitHubActionsManifestParser.load(resourcePath("github-actions-test")).toList()
+
+        results.filterIsInstance<PaketoManifest>().size shouldBe 2
+        results.filterIsInstance<FailedPaketoManifest>().size shouldBe 0
+    }
+
+    @Test
+    fun `returns empty sequence for directory with no workflow files`() {
+        val results = GitHubActionsManifestParser.load(resourcePath("all-manifests-test")).toList()
+
+        results.size shouldBe 0
+    }
+
+    @Test
+    fun `steps without buildpacks key are ignored`() {
+        val results = GitHubActionsManifestParser.load(resourcePath("github-actions-test")).toList()
+
+        val manifests = results.filterIsInstance<PaketoManifest>()
+        val nested = manifests.first { it.path.canonicalPath.contains("/subapp/.github/workflows/") }
+        // Only one buildpack in that file; the setup-node step has no buildpacks
+        nested.buildpacks.size shouldBe 1
+    }
+
+    private fun resourcePath(path: String) = File("src/test/resources/$path")
+}

--- a/src/test/kotlin/com/springernature/newversion/GitHubPullRequestPublisherTest.kt
+++ b/src/test/kotlin/com/springernature/newversion/GitHubPullRequestPublisherTest.kt
@@ -353,6 +353,70 @@ class GitHubPullRequestPublisherTest {
         }
     }
 
+    @Test
+    fun `a Paketo manifest file is updated using fileToken with colon separator`() {
+        val shell = CapturingShell(
+            mapOf(
+                ("git" to listOf("rev-parse", "--abbrev-ref", "HEAD")) to { "base-branch" }
+            )
+        )
+        val publisher = GitHubPullRequestPublisher(shell, Settings())
+        val manifest = createPaketoTestManifest()
+
+        publisher.publish(
+            BuildpackUpdate(
+                listOf(manifest),
+                VersionedBuildpack.createPaketo("paketobuildpacks/java:21.4.0"),
+                BuildpackVersion(SemanticVersion("21.5.0"), GitTag("v21.5.0"))
+            )
+        )
+
+        manifest.readText() shouldContain "paketobuildpacks/java:21.5.0"
+        manifest.readText() shouldBeEqualTo """buildpacks: paketobuildpacks/java:21.5.0"""
+    }
+
+    @Test
+    fun `a Paketo PR diff link is reconstructed from version when tag is null`() {
+        val shell = CapturingShell(
+            mapOf(
+                ("git" to listOf("rev-parse", "--abbrev-ref", "HEAD")) to { "base-branch" },
+                ("git" to listOf("branch", "-r")) to { "" }
+            )
+        )
+        val publisher = GitHubPullRequestPublisher(shell, Settings())
+        val manifest = createPaketoTestManifest()
+
+        publisher.publish(
+            BuildpackUpdate(
+                listOf(manifest),
+                VersionedBuildpack.createPaketo("paketobuildpacks/java:21.4.0"),
+                BuildpackVersion(SemanticVersion("21.5.0"), GitTag("v21.5.0"))
+            )
+        )
+
+        shell.commands shouldContain (
+            "hub" to listOf(
+                "pull-request", "--push",
+                "--message", "Update paketo-buildpacks/java to 21.5.0\n\n"
+                        + "Update paketo-buildpacks/java from 21.4.0 to 21.5.0.\n\n"
+                        + "* [Release Notes](https://github.com/paketo-buildpacks/java/releases/tag/v21.5.0)\n"
+                        + "* [Diff](https://github.com/paketo-buildpacks/java/compare/v21.4.0...v21.5.0)",
+                "--base", "base-branch", "--labels", "buildpack-update"
+            )
+        )
+    }
+
+    private fun createPaketoTestManifest(
+        file: File = File.createTempFile(
+            "github-pull-request-publisher-paketo-test",
+            ".yml"
+        )
+    ): File =
+        file.also {
+            it.deleteOnExit()
+            it.writeText("buildpacks: paketobuildpacks/java:21.4.0")
+        }
+
     private fun createTestManifest(
         file: File = File.createTempFile(
             "github-pull-request-publisher-test-manifest",

--- a/src/test/kotlin/com/springernature/newversion/HalfpipeManifestParserTest.kt
+++ b/src/test/kotlin/com/springernature/newversion/HalfpipeManifestParserTest.kt
@@ -1,0 +1,59 @@
+package com.springernature.newversion
+
+import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldContain
+import org.amshove.kluent.shouldContainAll
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class HalfpipeManifestParserTest {
+
+    @Test
+    fun `loads buildpacks from top-level halfpipe file`() {
+        val results = HalfpipeManifestParser.load(resourcePath("halfpipe-test")).toList()
+
+        val manifests = results.filterIsInstance<PaketoManifest>()
+        val topLevel = manifests.first { it.path.name == ".halfpipe.io" }
+        topLevel.buildpacks shouldContainAll listOf(
+            VersionedBuildpack.createPaketo("paketobuildpacks/java:21.4.0"),
+            VersionedBuildpack.createPaketo("paketobuildpacks/nodejs:1.3.0")
+        )
+    }
+
+    @Test
+    fun `loads buildpacks from nested halfpipe yaml file`() {
+        val results = HalfpipeManifestParser.load(resourcePath("halfpipe-test")).toList()
+
+        val manifests = results.filterIsInstance<PaketoManifest>()
+        val nested = manifests.first { it.path.name == ".halfpipe.io.yaml" }
+        nested.buildpacks shouldContain VersionedBuildpack.createPaketo("paketobuildpacks/java:5.0.0")
+    }
+
+    @Test
+    fun `finds exactly two manifest files in fixture`() {
+        val results = HalfpipeManifestParser.load(resourcePath("halfpipe-test")).toList()
+
+        results.filterIsInstance<PaketoManifest>().size shouldBe 2
+        results.filterIsInstance<FailedPaketoManifest>().size shouldBe 0
+    }
+
+    @Test
+    fun `skips tasks that are not of type buildpack`() {
+        val results = HalfpipeManifestParser.load(resourcePath("halfpipe-test")).toList()
+
+        val manifests = results.filterIsInstance<PaketoManifest>()
+        val topLevel = manifests.first { it.path.name == ".halfpipe.io" }
+        // only 2 buildpacks: the run task should be ignored
+        topLevel.buildpacks.size shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `returns empty sequence for directory with no halfpipe files`() {
+        val results = HalfpipeManifestParser.load(resourcePath("all-manifests-test")).toList()
+
+        results.size shouldBe 0
+    }
+
+    private fun resourcePath(path: String) = File("src/test/resources/$path")
+}

--- a/src/test/kotlin/com/springernature/newversion/SummaryWriterTest.kt
+++ b/src/test/kotlin/com/springernature/newversion/SummaryWriterTest.kt
@@ -23,7 +23,7 @@ class SummaryWriterTest {
             |
             |## success
             |
-            |* currentBuildpack VersionedBuildpack(name=test/buildpack1, url=https://a.host/path, version=1.3, tag=GitTag(value=v1.3)) has no update
+            |* currentBuildpack VersionedBuildpack(name=test/buildpack1, url=https://a.host/path, version=1.3, tag=GitTag(value=v1.3), fileToken=null) has no update
             |
             |Thanks for watching!
             |""".trimMargin()
@@ -50,11 +50,11 @@ class SummaryWriterTest {
             |
             |## failures
             |
-            |* VersionedBuildpack(name=test/buildpack1, url=https://a.host/path, version=1.3, tag=GitTag(value=v1.3)) could not be updated: java.lang.RuntimeException: Successful failure!
+            |* VersionedBuildpack(name=test/buildpack1, url=https://a.host/path, version=1.3, tag=GitTag(value=v1.3), fileToken=null) could not be updated: java.lang.RuntimeException: Successful failure!
             |
             |## success
             |
-            |* currentBuildpack VersionedBuildpack(name=test/buildpack1, url=https://a.host/path, version=1.3, tag=GitTag(value=v1.3)) has no update
+            |* currentBuildpack VersionedBuildpack(name=test/buildpack1, url=https://a.host/path, version=1.3, tag=GitTag(value=v1.3), fileToken=null) has no update
             |
             |Thanks for watching!
             |""".trimMargin()

--- a/src/test/kotlin/com/springernature/newversion/VersionedBuildpackTest.kt
+++ b/src/test/kotlin/com/springernature/newversion/VersionedBuildpackTest.kt
@@ -1,0 +1,35 @@
+package com.springernature.newversion
+
+import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class VersionedBuildpackTest {
+
+    @Test
+    fun `createPaketo parses org, repo and version from paketobuildpacks token`() {
+        val buildpack = VersionedBuildpack.createPaketo("paketobuildpacks/java:21.4.0")
+
+        buildpack.name shouldBeEqualTo "paketo-buildpacks/java"
+        buildpack.url shouldBeEqualTo "https://github.com/paketo-buildpacks/java"
+        buildpack.version shouldBeEqualTo SemanticVersion("21.4.0")
+        buildpack.tag shouldBe null
+        buildpack.fileToken shouldBeEqualTo "paketobuildpacks/java"
+    }
+
+    @Test
+    fun `createPaketo returns Unparseable version when token has no version`() {
+        val buildpack = VersionedBuildpack.createPaketo("paketobuildpacks/java")
+
+        buildpack.version shouldBe Unparseable
+    }
+
+    @Test
+    fun `existing CF buildpacks have null fileToken by default`() {
+        val buildpack = VersionedBuildpack.create(
+            "https://github.com/cloudfoundry/staticfile-buildpack#v1.5.17"
+        )
+
+        buildpack.fileToken shouldBe null
+    }
+}

--- a/src/test/resources/github-actions-test/.github/workflows/deploy.yml
+++ b/src/test/resources/github-actions-test/.github/workflows/deploy.yml
@@ -1,0 +1,19 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Deploy with java buildpack
+        uses: springernature/ee-action-buildpack@v1
+        with:
+          buildpacks: paketobuildpacks/java:21.4.0
+
+      - name: Run tests
+        run: ./gradlew test

--- a/src/test/resources/github-actions-test/subapp/.github/workflows/deploy.yml
+++ b/src/test/resources/github-actions-test/subapp/.github/workflows/deploy.yml
@@ -1,0 +1,21 @@
+name: Deploy Subapp
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Deploy nodejs
+        uses: springernature/ee-action-buildpack@v1
+        with:
+          buildpacks: paketobuildpacks/nodejs:1.3.0
+
+      - name: CI step without buildpacks
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18

--- a/src/test/resources/github-latest-paketo-java.json
+++ b/src/test/resources/github-latest-paketo-java.json
@@ -1,0 +1,16 @@
+{
+  "url": "https://api.github.com/repos/paketo-buildpacks/java/releases/99999999",
+  "html_url": "https://github.com/paketo-buildpacks/java/releases/tag/v21.5.0",
+  "id": 99999999,
+  "tag_name": "v21.5.0",
+  "target_commitish": "main",
+  "name": "v21.5.0",
+  "draft": false,
+  "prerelease": false,
+  "created_at": "2024-01-01T00:00:00Z",
+  "published_at": "2024-01-01T00:00:00Z",
+  "assets": [],
+  "tarball_url": "https://api.github.com/repos/paketo-buildpacks/java/tarball/v21.5.0",
+  "zipball_url": "https://api.github.com/repos/paketo-buildpacks/java/zipball/v21.5.0",
+  "body": "Release v21.5.0"
+}

--- a/src/test/resources/halfpipe-test/.halfpipe.io
+++ b/src/test/resources/halfpipe-test/.halfpipe.io
@@ -1,0 +1,13 @@
+team: my-team
+pipeline: my-pipeline
+
+tasks:
+  - type: buildpack
+    name: deploy
+    buildpacks:
+      - paketobuildpacks/java:21.4.0
+      - paketobuildpacks/nodejs:1.3.0
+
+  - type: run
+    name: test
+    script: ./test.sh

--- a/src/test/resources/halfpipe-test/subdir/.halfpipe.io.yaml
+++ b/src/test/resources/halfpipe-test/subdir/.halfpipe.io.yaml
@@ -1,0 +1,8 @@
+team: my-team
+pipeline: nested-pipeline
+
+tasks:
+  - type: buildpack
+    name: deploy
+    buildpacks:
+      - paketobuildpacks/java:5.0.0

--- a/src/test/resources/paketo-wiring-test/.halfpipe.io
+++ b/src/test/resources/paketo-wiring-test/.halfpipe.io
@@ -1,0 +1,8 @@
+team: my-team
+pipeline: my-pipeline
+
+tasks:
+  - type: buildpack
+    name: deploy
+    buildpacks:
+      - paketobuildpacks/java:21.4.0


### PR DESCRIPTION
Add functionality to check for Paketo buildpacks being used in GitHub Workflows and/or Halfpipe manifest files.

We check
* `**/halfpipe.io`, `**/halfpipe.io.yml`, `**/halfpipe.io.yaml`
* GitHub Actions manifests in `.github/workflows`

This is additive to existing functionality.