### PR TITLE
Detect workflow buildpack updates by default; opt in to PR creation via UPDATE_WORKFLOW_FILES

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ Pinned Paketo buildpacks passed to steps via the `buildpacks` input (e.g. when u
     buildpacks: paketobuildpacks/java:21.4.0
 ```
 
+> **Note:** By default, buildpack updates found in GitHub Actions workflow files are **detected and reported** in the
+> job summary only — no PR is created. This is because modifying `.github/workflows/` files requires the GitHub
+> **Workflows** permission, which is not available to a standard `GITHUB_TOKEN`.
+>
+> To enable automatic PR creation for workflow file updates, set `UPDATE_WORKFLOW_FILES=true` and use a GitHub App
+> that has the **"Workflows: Read and write"** permission (see [Opt-in: updating workflow files](#opt-in-updating-workflow-files) below).
+
 ## Example usage
 
 Create a file in your repo called `.github/workflows/buildpack-update.yml` and in it put this code (remember to update `your-team-email-address@springernature.com` to one that is correct for your team)
@@ -90,6 +97,62 @@ So, if the opened PR should run some automated tests, you will need a PAT (Perso
 
 When setting `GITHUB_STEP_SUMMARY_ENABLED` to `true` (default is `false`) a job summary is created, 
 see [example output](https://github.com/springernature/dpas/actions/runs/3691628035/attempts/1#summary-10080794385).
+
+## Opt-in: updating workflow files
+
+By default the action only **detects and reports** Paketo buildpack updates found in `.github/workflows/` files.
+It does not attempt to create PRs for them.
+
+To opt in to automatic PR creation for workflow file updates, two things are required:
+
+1. A GitHub App that has the **"Workflows: Read and write"** permission installed on your repository.
+2. The `UPDATE_WORKFLOW_FILES=true` environment variable set on the action step.
+
+### Why a special GitHub App is needed
+
+GitHub enforces that any push modifying files under `.github/workflows/` must be authorised by a token whose
+underlying credential has the `workflows` scope.  The built-in `GITHUB_TOKEN` never has this scope. There is no `workflows:` key in the workflow-level `permissions:` YAML
+block — it must be granted at the GitHub App installation level.
+
+### Example with `actions/create-github-app-token`
+
+```yaml
+name: buildpack-update
+on:
+  schedule:
+    - cron: '0 4 * * 1-5'
+  workflow_dispatch:
+
+jobs:
+  buildpack_updates_job:
+    runs-on: ee-runner
+    timeout-minutes: 30
+    name: buildpack updates
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.MY_APP_ID }}
+          private-key: ${{ secrets.MY_APP_PRIVATE_KEY }}
+
+      - name: Check out the repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: run cf-buildpack-update-action
+        uses: springernature/cf-buildpack-update-action@v1.2.0
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          AUTHOR_EMAIL: your-team-email-address@springernature.com
+          AUTHOR_NAME: Buildpack Update Action
+          GITHUB_STEP_SUMMARY_ENABLED: true
+          UPDATE_WORKFLOW_FILES: true
+```
+
+The GitHub App must be installed with the **"Workflows: Read and write"** permission in addition to
+the usual **"Contents: Read and write"** and **"Pull requests: Read and write"** permissions.
 
 ## Keep *your* action up-to-date
 
@@ -132,3 +195,4 @@ Copyright Springer Nature
 [history]: HISTORY.md
 
 [license]: LICENSE 
+

--- a/src/main/kotlin/com/springernature/newversion/BuildpackVersionChecker.kt
+++ b/src/main/kotlin/com/springernature/newversion/BuildpackVersionChecker.kt
@@ -7,21 +7,29 @@ import java.io.File
 
 sealed class ChecksResult {
     abstract fun exitStatus(): Int
+    abstract val detectedWorkflowUpdates: List<BuildpackUpdate>
 }
 
-data class SuccessfulChecks(val updates: List<BuildpackUpdate>) : ChecksResult() {
+data class SuccessfulChecks(
+    val updates: List<BuildpackUpdate>,
+    override val detectedWorkflowUpdates: List<BuildpackUpdate> = emptyList()
+) : ChecksResult() {
     override fun exitStatus() = 0
 }
 
-data class FailedChecks(val updates: List<BuildpackUpdate>, val errors: Map<BuildpackUpdate, Exception>) :
-    ChecksResult() {
+data class FailedChecks(
+    val updates: List<BuildpackUpdate>,
+    val errors: Map<BuildpackUpdate, Exception>,
+    override val detectedWorkflowUpdates: List<BuildpackUpdate> = emptyList()
+) : ChecksResult() {
     override fun exitStatus() = 1
 }
 
 class BuildpackVersionChecker(
     private val manifestPath: File,
     private val buildpackUpdateChecker: BuildpackUpdateChecker,
-    private val publisher: Publisher
+    private val publisher: Publisher,
+    private val settings: Settings = Settings()
 ) {
 
     fun performChecks(): ChecksResult {
@@ -32,11 +40,21 @@ class BuildpackVersionChecker(
             .flatMap { ManifestBuildpack.from(it) }
             .map { ManifestEntry(it.manifest, it.buildpack) }
 
-        val paketoBuildpacks = (HalfpipeManifestParser.load(manifestPath) + GitHubActionsManifestParser.load(manifestPath))
+        val halfpipeBuildpacks = HalfpipeManifestParser.load(manifestPath)
             .flatMap { PaketoManifestBuildpack.from(it) }
             .map { ManifestEntry(it.manifest, it.buildpack) }
 
-        val updates = (cfBuildpacks + paketoBuildpacks)
+        val githubActionsBuildpacks = GitHubActionsManifestParser.load(manifestPath)
+            .flatMap { PaketoManifestBuildpack.from(it) }
+            .map { ManifestEntry(it.manifest, it.buildpack) }
+            .toList()
+
+        val updateWorkflowFiles = settings.lookup(Setting.UPDATE_WORKFLOW_FILES).toBoolean()
+
+        val toPublish = cfBuildpacks + halfpipeBuildpacks +
+                if (updateWorkflowFiles) githubActionsBuildpacks else emptyList()
+
+        val updates = toPublish
             .filter { it.buildpack.version != Unparseable }
             .groupBy { it.buildpack }
             .map { (buildpack, entries) ->
@@ -54,11 +72,30 @@ class BuildpackVersionChecker(
                     errors[it] = e
                 }
             }
+
+        val detectedWorkflowUpdates = if (!updateWorkflowFiles) {
+            githubActionsBuildpacks
+                .filter { it.buildpack.version != Unparseable }
+                .groupBy { it.buildpack }
+                .mapNotNull { (buildpack, entries) ->
+                    try {
+                        BuildpackUpdate(
+                            entries.map { it.manifest },
+                            buildpack,
+                            buildpackUpdateChecker.findLatestVersion(buildpack)
+                        ).takeIf { it.hasUpdate() }
+                    } catch (e: Exception) {
+                        LOG.warn("Failed to check version for workflow buildpack {}: {}", buildpack.name, e.message)
+                        null
+                    }
+                }
+        } else emptyList()
+
         LOG.info("Done")
         return if (errors.isNotEmpty())
-            FailedChecks(updates, errors)
+            FailedChecks(updates, errors, detectedWorkflowUpdates)
         else
-            SuccessfulChecks(updates)
+            SuccessfulChecks(updates, detectedWorkflowUpdates)
     }
 
     companion object {

--- a/src/main/kotlin/com/springernature/newversion/Main.kt
+++ b/src/main/kotlin/com/springernature/newversion/Main.kt
@@ -13,7 +13,7 @@ fun main() {
     val manifestPath = File(".")
     val summaryWriter = SummaryWriter(settings)
 
-    val results = BuildpackVersionChecker(manifestPath, buildpackUpdateChecker, publisher)
+    val results = BuildpackVersionChecker(manifestPath, buildpackUpdateChecker, publisher, settings)
         .performChecks()
     when (results) {
         is FailedChecks ->

--- a/src/main/kotlin/com/springernature/newversion/Settings.kt
+++ b/src/main/kotlin/com/springernature/newversion/Settings.kt
@@ -5,7 +5,8 @@ enum class Setting(val key: String, val defaultValue: String) {
     AUTHOR_EMAIL("AUTHOR_EMAIL", "do_not_reply@springernature.com"),
     AUTHOR_NAME("AUTHOR_NAME", "Buildpack Update Action"),
     GITHUB_STEP_SUMMARY("GITHUB_STEP_SUMMARY", "/dev/null"),
-    GITHUB_STEP_SUMMARY_ENABLED("GITHUB_STEP_SUMMARY_ENABLED", false.toString())
+    GITHUB_STEP_SUMMARY_ENABLED("GITHUB_STEP_SUMMARY_ENABLED", false.toString()),
+    UPDATE_WORKFLOW_FILES("UPDATE_WORKFLOW_FILES", false.toString())
 }
 
 class Settings(private val values: Map<String, String> = mapOf()) {

--- a/src/main/kotlin/com/springernature/newversion/SummaryWriter.kt
+++ b/src/main/kotlin/com/springernature/newversion/SummaryWriter.kt
@@ -22,6 +22,7 @@ class SummaryWriter(val settings: Settings) {
             }
             is SuccessfulChecks -> writeSuccessfulUpdates(results.updates)
         }
+        writeDetectedWorkflowUpdates(results.detectedWorkflowUpdates)
         writeFooter(file)
     }
 
@@ -51,6 +52,24 @@ class SummaryWriter(val settings: Settings) {
             "\n## failures\n" + "\n"
         )
         errors.forEach { file.appendText("* ${it.key.currentBuildpack} could not be updated: ${it.value}\n") }
+    }
+
+    private fun writeDetectedWorkflowUpdates(updates: List<BuildpackUpdate>) {
+        if (updates.isEmpty()) {
+            return
+        }
+
+        file.appendText("\n## detected workflow buildpack updates\n\n")
+        file.appendText(
+            "The following buildpacks were found in GitHub Actions workflow files and have updates available.\n" +
+            "To enable automatic PR creation, set `UPDATE_WORKFLOW_FILES=true` " +
+            "(requires a GitHub App with the **Workflows** permission — see README).\n\n"
+        )
+        updates.forEach {
+            file.appendText("* currentBuildpack ${it.currentBuildpack} ")
+            file.appendText("has an update to " + it.latestUpdate)
+            file.appendText("\n")
+        }
     }
 
     private fun writeFooter(file: File) {

--- a/src/test/kotlin/com/springernature/newversion/BuildpackVersionCheckerTest.kt
+++ b/src/test/kotlin/com/springernature/newversion/BuildpackVersionCheckerTest.kt
@@ -186,6 +186,71 @@ class BuildpackVersionCheckerTest {
     }
 
     @Test
+    fun `paketo buildpacks in github actions workflows are detected but not published by default`() {
+        val fixtureDir = File("src/test/resources/github-actions-test")
+        fixtureDir.exists() shouldBe true
+
+        val settings = Settings(mapOf(GIT_HUB_API_URL.key to baseUrl))
+        val capturingPublisher = CapturingPublisher()
+        val buildpackVersionChecker = BuildpackVersionChecker(
+            fixtureDir,
+            GitHubBuildpackUpdateChecker(HttpClient.newBuilder().build(), settings),
+            capturingPublisher,
+            settings
+        )
+
+        val results = buildpackVersionChecker.performChecks()
+        results shouldBeInstanceOf SuccessfulChecks::class
+
+        capturingPublisher.updates().size shouldBe 0
+
+        val detected = results.detectedWorkflowUpdates.sortedBy { it.currentBuildpack.name }
+        detected.size shouldBe 2
+
+        detected[0].currentBuildpack.name shouldBeEqualTo "paketo-buildpacks/java"
+        detected[0].currentBuildpack.version shouldBeEqualTo SemanticVersion("21.4.0")
+        detected[0].latestUpdate.version shouldBeEqualTo SemanticVersion("21.5.0")
+
+        detected[1].currentBuildpack.name shouldBeEqualTo "paketo-buildpacks/nodejs"
+        detected[1].currentBuildpack.version shouldBeEqualTo SemanticVersion("1.3.0")
+        detected[1].latestUpdate.version shouldBeEqualTo SemanticVersion("1.4.0")
+    }
+
+    @Test
+    fun `paketo buildpacks in github actions workflows are published when UPDATE_WORKFLOW_FILES is true`() {
+        val fixtureDir = File("src/test/resources/github-actions-test")
+        fixtureDir.exists() shouldBe true
+
+        val settings = Settings(
+            mapOf(
+                GIT_HUB_API_URL.key to baseUrl,
+                Setting.UPDATE_WORKFLOW_FILES.key to "true"
+            )
+        )
+        val capturingPublisher = CapturingPublisher()
+        val buildpackVersionChecker = BuildpackVersionChecker(
+            fixtureDir,
+            GitHubBuildpackUpdateChecker(HttpClient.newBuilder().build(), settings),
+            capturingPublisher,
+            settings
+        )
+
+        val results = buildpackVersionChecker.performChecks()
+        results shouldBeInstanceOf SuccessfulChecks::class
+
+        val updates = capturingPublisher.updates().sortedBy { it.currentBuildpack.name }
+        updates.size shouldBe 2
+
+        updates[0].currentBuildpack.name shouldBeEqualTo "paketo-buildpacks/java"
+        updates[0].latestUpdate.version shouldBeEqualTo SemanticVersion("21.5.0")
+
+        updates[1].currentBuildpack.name shouldBeEqualTo "paketo-buildpacks/nodejs"
+        updates[1].latestUpdate.version shouldBeEqualTo SemanticVersion("1.4.0")
+
+        results.detectedWorkflowUpdates.size shouldBe 0
+    }
+
+    @Test
     fun `a failed publish should lead to failed check`() {
         val manifest = File("src/test/resources/manifest.yml")
         manifest.exists() shouldBe true
@@ -248,6 +313,12 @@ class BuildpackVersionCheckerTest {
                     server,
                     "/repos/paketo-buildpacks/java/releases/latest",
                     "/github-latest-paketo-java.json"
+                )
+            }.also { server ->
+                context(
+                    server,
+                    "/repos/paketo-buildpacks/nodejs/releases/latest",
+                    "/github-latest-paketo-nodejs.json"
                 )
             }
 

--- a/src/test/kotlin/com/springernature/newversion/SummaryWriterTest.kt
+++ b/src/test/kotlin/com/springernature/newversion/SummaryWriterTest.kt
@@ -8,6 +8,32 @@ import java.io.File
 class SummaryWriterTest {
 
     @Test
+    fun `detected workflow buildpack updates appear in report`() {
+        val tempFile = getTempReportFile()
+        val settings = Settings(
+            mapOf(
+                Setting.GITHUB_STEP_SUMMARY.key to tempFile.path,
+                Setting.GITHUB_STEP_SUMMARY_ENABLED.key to true.toString()
+            )
+        )
+        val results = SuccessfulChecks(emptyList(), listOf(detectedWorkflowUpdate))
+        SummaryWriter(settings).write(results)
+
+        tempFile.readText() shouldBeEqualTo """
+            |# CF buildpack update action results
+            |
+            |## detected workflow buildpack updates
+            |
+            |The following buildpacks were found in GitHub Actions workflow files and have updates available.
+            |To enable automatic PR creation, set `UPDATE_WORKFLOW_FILES=true` (requires a GitHub App with the **Workflows** permission — see README).
+            |
+            |* currentBuildpack VersionedBuildpack(name=test/buildpack1, url=https://a.host/path, version=1.3, tag=GitTag(value=v1.3), fileToken=null) has an update to BuildpackVersion(version=1.4.0, tag=GitTag(value=v1.4.0))
+            |
+            |Thanks for watching!
+            |""".trimMargin()
+    }
+
+    @Test
     fun `successful checks report`() {
         val tempFile = getTempReportFile()
         val settings = Settings(
@@ -95,6 +121,12 @@ class SummaryWriterTest {
             listOf(File("a/path")),
             VersionedBuildpack("test/buildpack1", "https://a.host/path", SemanticVersion("1.3"), GitTag("v1.3")),
             BuildpackVersion(SemanticVersion("1.2.4"), GitTag("v1.2.4"))
+        )
+
+        val detectedWorkflowUpdate = BuildpackUpdate(
+            listOf(File("a/path")),
+            VersionedBuildpack("test/buildpack1", "https://a.host/path", SemanticVersion("1.3"), GitTag("v1.3")),
+            BuildpackVersion(SemanticVersion("1.4.0"), GitTag("v1.4.0"))
         )
 
         val successfulChecksResults = SuccessfulChecks(listOf(buildpackUpdate))

--- a/src/test/resources/github-latest-paketo-nodejs.json
+++ b/src/test/resources/github-latest-paketo-nodejs.json
@@ -1,0 +1,16 @@
+{
+  "url": "https://api.github.com/repos/paketo-buildpacks/nodejs/releases/99999998",
+  "html_url": "https://github.com/paketo-buildpacks/nodejs/releases/tag/v1.4.0",
+  "id": 99999998,
+  "tag_name": "v1.4.0",
+  "target_commitish": "main",
+  "name": "v1.4.0",
+  "draft": false,
+  "prerelease": false,
+  "created_at": "2024-01-01T00:00:00Z",
+  "published_at": "2024-01-01T00:00:00Z",
+  "assets": [],
+  "tarball_url": "https://api.github.com/repos/paketo-buildpacks/nodejs/tarball/v1.4.0",
+  "zipball_url": "https://api.github.com/repos/paketo-buildpacks/nodejs/zipball/v1.4.0",
+  "body": "Release v1.4.0"
+}


### PR DESCRIPTION
Pushing changes to .github/workflows/ files requires a GitHub App with the Workflows permission, which is not available to a standard GITHUB_TOKEN.

By default the action now only detects and reports CNB buildpack updates found in GitHub Actions workflow files (included in the job summary), and does not attempt to push a branch or open a PR for them.

Set `UPDATE_WORKFLOW_FILES=true` to restore the previous behaviour; this requires a GitHub App token with the Workflows permission passed to both actions/checkout and the action's GITHUB_TOKEN env var (see README).